### PR TITLE
Deploy Normalized Props

### DIFF
--- a/Public/Initialize-LMStandardNormProps.ps1
+++ b/Public/Initialize-LMStandardNormProps.ps1
@@ -93,7 +93,6 @@ Function Initialize-LMStandardNormProps {
         }Else {
             Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
-        End {}
     }
     End {}
 }

--- a/Public/Initialize-LMStandardNormProps.ps1
+++ b/Public/Initialize-LMStandardNormProps.ps1
@@ -1,84 +1,113 @@
 <#
 .SYNOPSIS
-    Initializes standard normalized properties in LogicMonitor.
+    Initializes standard normalized properties in LogicMonitor, with error-checking.
 
 .DESCRIPTION
-    This script defines a set of "standard" properties (like location.region, environment, etc.), 
-    then loops through each property to call "New-LMNormalizedProperties" with its alias 
-    and array of possible property names.
+    This script:
+    1. Checks that you are connected to LogicMonitor (via Connect-LMAccount).
+    2. Verifies that the New-LMNormalizedProperties function is available.
+    3. Iterates a list of standard property aliases (e.g. "location.region", "owner", etc.)
+       and calls New-LMNormalizedProperties for each alias and its possible sources.
+    4. Uses error handling to report and stop if something goes wrong.
 
 .EXAMPLE
     .\Initialize-LMStandardNormProps.ps1
-    Initializes all standard normalized properties.
+    This will attempt to create/update the normalized properties in LogicMonitor.
 
 .NOTES
-    - Assumes you are already connected to LogicMonitor (e.g., via Connect-LMAccount).
-    - Requires a function named "New-LMNormalizedProperties" in scope.
+    - Assumes the official or internal LM PowerShell module is already imported,
+      giving access to Get-LMAccountStatus, Connect-LMAccount, and New-LMNormalizedProperties.
+    - Run Connect-LMAccount before invoking this script.
 #>
 
 [CmdletBinding()]
 Param()
 
-# 1. Define the list of standard normalized properties as an array of PSCustomObjects.
-$NormalizedProperties = @(
-    [PSCustomObject]@{
-        Alias      = 'location.region'
-        Properties = @('sn.location.region','location.region','auto.location.region')
-    },
-    [PSCustomObject]@{
-        Alias      = 'location.country'
-        Properties = @('sn.location.country','location.country','auto.location.country')
-    },
-    [PSCustomObject]@{
-        Alias      = 'location.state'
-        Properties = @('sn.location.state','location.state','auto.location.state')
-    },
-    [PSCustomObject]@{
-        Alias      = 'location.city'
-        Properties = @('sn.location.city','location.city','auto.location.city')
-    },
-    [PSCustomObject]@{
-        Alias      = 'location.site'
-        Properties = @('sn.location.street','location.site','auto.location.site')
-    },
-    [PSCustomObject]@{
-        Alias      = 'location.type'
-        Properties = @('sn.location.type','location.type','auto.location.type')
-    },
-    [PSCustomObject]@{
-        Alias      = 'environment'
-        Properties = @('sn.environment','environment','system.aws.tag.environment','system.azure.tag.environment','system.gcp.tag.environment')
-    },
-    [PSCustomObject]@{
-        Alias      = 'owner'
-        Properties = @('sn.owner','owner','system.aws.tag.owner','system.azure.tag.owner','system.gcp.tag.owner')
-    },
-    [PSCustomObject]@{
-        Alias      = 'version'
-        Properties = @('version','system.aws.tag.version','system.azure.tag.version','system.gcp.tag.version')
-    },
-    [PSCustomObject]@{
-        Alias      = 'service'
-        Properties = @('sn.service.name','service','system.aws.tag.service','system.azure.tag.service','system.gcp.tag.service')
-    },
-    [PSCustomObject]@{
-        Alias      = 'service_component'
-        Properties = @('sn.service_component','service_component','system.aws.tag.service_component','system.azure.tag.service_component','system.gcp.tag.service_component')
-    },
-    [PSCustomObject]@{
-        Alias      = 'application'
-        Properties = @('sn.application','application','system.aws.tag.application','system.azure.tag.application','system.gcp.tag.application')
-    },
-    [PSCustomObject]@{
-        Alias      = 'customer'
-        Properties = @('sn.customer','customer','system.aws.tag.customer','system.azure.tag.customer','system.gcp.tag.customer')
+try {
+    # 1. Check if we are logged into LogicMonitor
+    $accountStatus = Get-LMAccountStatus
+    if (!$accountStatus -or -not $accountStatus.Valid) {
+        throw "You are not logged in to LogicMonitor. Please run Connect-LMAccount first."
     }
-)
 
-# 2. Loop through each entry and call New-LMNormalizedProperties
-foreach ($item in $NormalizedProperties) {
-    Write-Host "Setting Normalized Property Alias: $($item.Alias)"
-    New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
+    # 2. Verify that New-LMNormalizedProperties function is available
+    $nmPropCommand = Get-Command -Name "New-LMNormalizedProperties" -ErrorAction SilentlyContinue
+    if (!$nmPropCommand) {
+        throw "Function 'New-LMNormalizedProperties' not found. Ensure it is loaded or imported before running."
+    }
+
+    # 3. Define your list of standard normalized properties as an array of PSCustomObjects
+    $NormalizedProperties = @(
+        [PSCustomObject]@{
+            Alias      = 'location.region'
+            Properties = @('sn.location.region','location.region','auto.location.region')
+        },
+        [PSCustomObject]@{
+            Alias      = 'location.country'
+            Properties = @('sn.location.country','location.country','auto.location.country')
+        },
+        [PSCustomObject]@{
+            Alias      = 'location.state'
+            Properties = @('sn.location.state','location.state','auto.location.state')
+        },
+        [PSCustomObject]@{
+            Alias      = 'location.city'
+            Properties = @('sn.location.city','location.city','auto.location.city')
+        },
+        [PSCustomObject]@{
+            Alias      = 'location.site'
+            Properties = @('sn.location.street','location.site','auto.location.site')
+        },
+        [PSCustomObject]@{
+            Alias      = 'location.type'
+            Properties = @('sn.location.type','location.type','auto.location.type')
+        },
+        [PSCustomObject]@{
+            Alias      = 'environment'
+            Properties = @('sn.environment','environment','system.aws.tag.environment','system.azure.tag.environment','system.gcp.tag.environment')
+        },
+        [PSCustomObject]@{
+            Alias      = 'owner'
+            Properties = @('sn.owner','owner','system.aws.tag.owner','system.azure.tag.owner','system.gcp.tag.owner')
+        },
+        [PSCustomObject]@{
+            Alias      = 'version'
+            Properties = @('version','system.aws.tag.version','system.azure.tag.version','system.gcp.tag.version')
+        },
+        [PSCustomObject]@{
+            Alias      = 'service'
+            Properties = @('sn.service.name','service','system.aws.tag.service','system.azure.tag.service','system.gcp.tag.service')
+        },
+        [PSCustomObject]@{
+            Alias      = 'service_component'
+            Properties = @('sn.service_component','service_component','system.aws.tag.service_component','system.azure.tag.service_component','system.gcp.tag.service_component')
+        },
+        [PSCustomObject]@{
+            Alias      = 'application'
+            Properties = @('sn.application','application','system.aws.tag.application','system.azure.tag.application','system.gcp.tag.application')
+        },
+        [PSCustomObject]@{
+            Alias      = 'customer'
+            Properties = @('sn.customer','customer','system.aws.tag.customer','system.azure.tag.customer','system.gcp.tag.customer')
+        }
+    )
+
+    # 4. Loop through and create/update normalized properties
+    foreach ($item in $NormalizedProperties) {
+        Write-Host "Configuring normalized property Alias: $($item.Alias)"
+        try {
+            New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
+            Write-Host "  --> Success: Alias '$($item.Alias)'"
+        }
+        catch {
+            Write-Error "  --> Failed to set Alias '$($item.Alias)': $($_.Exception.Message)"
+        }
+    }
+
+    Write-Host "`nAll standard normalized properties have been processed."
 }
-
-Write-Host "All standard normalized properties have been initialized."
+catch {
+    # If we get here, something prevented the entire script from running
+    Write-Error "Initialize-LMStandardNormProps: $($_.Exception.Message)"
+    return
+}

--- a/Public/Initialize-LMStandardNormProps.ps1
+++ b/Public/Initialize-LMStandardNormProps.ps1
@@ -76,23 +76,20 @@ Function Initialize-LMStandardNormProps {
             $ExistingProps = Get-LMNormalizedProperties
             foreach ($item in $NormalizedProperties) {
                 Write-Host "Checking alias: $($item.Alias)"
-            
+
                 # Get the existing rows for this alias (if any)
                 $aliasRows = $ExistingProps | Where-Object { $_.alias -eq $item.Alias }
-                Write-Host($aliasRows)
-            
                 if (-not $aliasRows) {
                     # Alias doesn't exist at all, so create it with all standard properties
                     Write-Host " -> Alias '$($item.Alias)' does not exist. Creating it with all standard properties..."
                     New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
-                    continue
                 }
                 else {
                     Write-Host " -> Alias '$($item.Alias)' found. Checking for any missing properties..."
             
                     # Gather which standard properties are missing
-                    $existingProps = $aliasRows.hostProperty
-                    $missingProps  = $item.Properties | Where-Object { $existingProps -notcontains $_ }
+                    $aliasHostProps = $aliasRows.hostProperty
+                    $missingProps   = $item.Properties | Where-Object { $aliasHostProps -notcontains $_ }
 
                     if ($missingProps) {
                         Write-Host "    Missing properties: $($missingProps -join ', ')"

--- a/Public/Initialize-LMStandardNormProps.ps1
+++ b/Public/Initialize-LMStandardNormProps.ps1
@@ -1,113 +1,100 @@
 <#
 .SYNOPSIS
-    Initializes standard normalized properties in LogicMonitor, with error-checking.
+    Initializes standard normalized properties in LogicMonitor.
 
 .DESCRIPTION
     This script:
-    1. Checks that you are connected to LogicMonitor (via Connect-LMAccount).
-    2. Verifies that the New-LMNormalizedProperties function is available.
-    3. Iterates a list of standard property aliases (e.g. "location.region", "owner", etc.)
-       and calls New-LMNormalizedProperties for each alias and its possible sources.
-    4. Uses error handling to report and stop if something goes wrong.
+    Checks that you are connected to LogicMonitor (via Connect-LMAccount).
+    Iterates a list of standard property aliases (e.g. "location.region", "owner", etc.)
+    and calls New-LMNormalizedProperties for each alias and its possible sources.
 
 .EXAMPLE
-    .\Initialize-LMStandardNormProps.ps1
+    Initialize-LMStandardNormProps.ps1
     This will attempt to create/update the normalized properties in LogicMonitor.
-
-.NOTES
-    - Assumes the official or internal LM PowerShell module is already imported,
-      giving access to Get-LMAccountStatus, Connect-LMAccount, and New-LMNormalizedProperties.
-    - Run Connect-LMAccount before invoking this script.
 #>
+Function Initialize-LMStandardNormProps {
 
-[CmdletBinding()]
-Param()
+    [CmdletBinding()]
+    Param()
 
-try {
-    # 1. Check if we are logged into LogicMonitor
-    $accountStatus = Get-LMAccountStatus
-    if (!$accountStatus -or -not $accountStatus.Valid) {
-        throw "You are not logged in to LogicMonitor. Please run Connect-LMAccount first."
-    }
+    Begin {}
+    Process {
+        #Check if we are logged in and have valid api creds
+        If ($(Get-LMAccountStatus).Valid) {
+            # Define your list of standard normalized properties as an array of PSCustomObjects
+            $NormalizedProperties = @(
+                [PSCustomObject]@{
+                    Alias      = 'location.region'
+                    Properties = @('sn.location.region','location.region','auto.location.region')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'location.country'
+                    Properties = @('sn.location.country','location.country','auto.location.country')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'location.state'
+                    Properties = @('sn.location.state','location.state','auto.location.state')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'location.city'
+                    Properties = @('sn.location.city','location.city','auto.location.city')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'location.site'
+                    Properties = @('sn.location.street','location.site','auto.location.site')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'location.type'
+                    Properties = @('sn.location.type','location.type','auto.location.type')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'environment'
+                    Properties = @('sn.environment','environment','system.aws.tag.environment','system.azure.tag.environment','system.gcp.tag.environment')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'owner'
+                    Properties = @('sn.owner','owner','system.aws.tag.owner','system.azure.tag.owner','system.gcp.tag.owner')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'version'
+                    Properties = @('version','system.aws.tag.version','system.azure.tag.version','system.gcp.tag.version')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'service'
+                    Properties = @('sn.service.name','service','system.aws.tag.service','system.azure.tag.service','system.gcp.tag.service')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'service_component'
+                    Properties = @('sn.service_component','service_component','system.aws.tag.service_component','system.azure.tag.service_component','system.gcp.tag.service_component')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'application'
+                    Properties = @('sn.application','application','system.aws.tag.application','system.azure.tag.application','system.gcp.tag.application')
+                },
+                [PSCustomObject]@{
+                    Alias      = 'customer'
+                    Properties = @('sn.customer','customer','system.aws.tag.customer','system.azure.tag.customer','system.gcp.tag.customer')
+                }
+            )
+            
+            foreach ($item in $NormalizedProperties) {
+                Write-Host "Configuring normalized property Alias: $($item.Alias)"
+                try {
+                    New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
+                    Write-Host "  --> Success: Alias '$($item.Alias)'"
+                }
+                catch {
+                    Write-Error "  --> Failed to set Alias '$($item.Alias)': $($_.Exception.Message)"
+                }
+            }
+        
+            Write-Host "`nAll standard normalized properties have been processed."
 
-    # 2. Verify that New-LMNormalizedProperties function is available
-    $nmPropCommand = Get-Command -Name "New-LMNormalizedProperties" -ErrorAction SilentlyContinue
-    if (!$nmPropCommand) {
-        throw "Function 'New-LMNormalizedProperties' not found. Ensure it is loaded or imported before running."
-    }
-
-    # 3. Define your list of standard normalized properties as an array of PSCustomObjects
-    $NormalizedProperties = @(
-        [PSCustomObject]@{
-            Alias      = 'location.region'
-            Properties = @('sn.location.region','location.region','auto.location.region')
-        },
-        [PSCustomObject]@{
-            Alias      = 'location.country'
-            Properties = @('sn.location.country','location.country','auto.location.country')
-        },
-        [PSCustomObject]@{
-            Alias      = 'location.state'
-            Properties = @('sn.location.state','location.state','auto.location.state')
-        },
-        [PSCustomObject]@{
-            Alias      = 'location.city'
-            Properties = @('sn.location.city','location.city','auto.location.city')
-        },
-        [PSCustomObject]@{
-            Alias      = 'location.site'
-            Properties = @('sn.location.street','location.site','auto.location.site')
-        },
-        [PSCustomObject]@{
-            Alias      = 'location.type'
-            Properties = @('sn.location.type','location.type','auto.location.type')
-        },
-        [PSCustomObject]@{
-            Alias      = 'environment'
-            Properties = @('sn.environment','environment','system.aws.tag.environment','system.azure.tag.environment','system.gcp.tag.environment')
-        },
-        [PSCustomObject]@{
-            Alias      = 'owner'
-            Properties = @('sn.owner','owner','system.aws.tag.owner','system.azure.tag.owner','system.gcp.tag.owner')
-        },
-        [PSCustomObject]@{
-            Alias      = 'version'
-            Properties = @('version','system.aws.tag.version','system.azure.tag.version','system.gcp.tag.version')
-        },
-        [PSCustomObject]@{
-            Alias      = 'service'
-            Properties = @('sn.service.name','service','system.aws.tag.service','system.azure.tag.service','system.gcp.tag.service')
-        },
-        [PSCustomObject]@{
-            Alias      = 'service_component'
-            Properties = @('sn.service_component','service_component','system.aws.tag.service_component','system.azure.tag.service_component','system.gcp.tag.service_component')
-        },
-        [PSCustomObject]@{
-            Alias      = 'application'
-            Properties = @('sn.application','application','system.aws.tag.application','system.azure.tag.application','system.gcp.tag.application')
-        },
-        [PSCustomObject]@{
-            Alias      = 'customer'
-            Properties = @('sn.customer','customer','system.aws.tag.customer','system.azure.tag.customer','system.gcp.tag.customer')
+        }Else {
+            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
         }
-    )
-
-    # 4. Loop through and create/update normalized properties
-    foreach ($item in $NormalizedProperties) {
-        Write-Host "Configuring normalized property Alias: $($item.Alias)"
-        try {
-            New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
-            Write-Host "  --> Success: Alias '$($item.Alias)'"
-        }
-        catch {
-            Write-Error "  --> Failed to set Alias '$($item.Alias)': $($_.Exception.Message)"
-        }
+        End {}
     }
-
-    Write-Host "`nAll standard normalized properties have been processed."
+    End {}
 }
-catch {
-    # If we get here, something prevented the entire script from running
-    Write-Error "Initialize-LMStandardNormProps: $($_.Exception.Message)"
-    return
-}
+

--- a/Public/Initialize-LMStandardNormProps.ps1
+++ b/Public/Initialize-LMStandardNormProps.ps1
@@ -4,14 +4,17 @@
 
 .DESCRIPTION
     This script:
-    Checks that you are connected to LogicMonitor (via Connect-LMAccount).
-    Iterates a list of standard property aliases (e.g. "location.region", "owner", etc.)
-    and calls New-LMNormalizedProperties for each alias and its possible sources.
+    1. Verifies that you are connected to LogicMonitor (via Connect-LMAccount).
+    2. Iterates through a list of standard property aliases (e.g., "location.region", "owner", etc.).
+    3. For each alias, it calls New-LMNormalizedProperties if the alias is missing,
+       or Set-LMNormalizedProperties if it is partially missing some properties.
 
 .EXAMPLE
-    Initialize-LMStandardNormProps.ps1
-    This will attempt to create/update the normalized properties in LogicMonitor.
+    PS> Initialize-LMStandardNormProps
+
+    This will attempt to create/update the standardized normalized properties in LogicMonitor.
 #>
+
 Function Initialize-LMStandardNormProps {
 
     [CmdletBinding()]
@@ -19,96 +22,102 @@ Function Initialize-LMStandardNormProps {
 
     Begin {}
     Process {
-        #Check if we are logged in and have valid api creds
-        If ($(Get-LMAccountStatus).Valid) {
-            # Define your list of standard normalized properties as an array of PSCustomObjects
-            $NormalizedProperties = @(
-                [PSCustomObject]@{
-                    Alias      = 'location.region'
-                    Properties = @('location.region','auto.location.region')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'location.country'
-                    Properties = @('location.country','auto.location.country')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'location.state'
-                    Properties = @('location.state','auto.location.state')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'location.city'
-                    Properties = @('location.city','auto.location.city')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'location.site'
-                    Properties = @('location.site','auto.location.site')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'location.type'
-                    Properties = @('location.type','auto.location.type')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'environment'
-                    Properties = @('environment','system.aws.tag.environment','system.azure.tag.environment','system.gcp.tag.environment')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'owner'
-                    Properties = @('owner','system.aws.tag.owner','system.azure.tag.owner','system.gcp.tag.owner')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'version'
-                    Properties = @('version','system.aws.tag.version','system.azure.tag.version','system.gcp.tag.version')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'service'
-                    Properties = @('service','system.aws.tag.service','system.azure.tag.service','system.gcp.tag.service')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'service_component'
-                    Properties = @('service_component','system.aws.tag.service_component','system.azure.tag.service_component','system.gcp.tag.service_component')
-                },
-                [PSCustomObject]@{
-                    Alias      = 'application'
-                    Properties = @('application','system.aws.tag.application','system.azure.tag.application','system.gcp.tag.application')
-                }
-            )
-            # Retrieve existing props so we don't overwrite customers existing values. 
-            $ExistingProps = Get-LMNormalizedProperties
-            foreach ($item in $NormalizedProperties) {
-                Write-Host "Checking alias: $($item.Alias)"
+        # 1. Check if we are logged in with valid LogicMonitor API credentials
+        If (-not (Get-LMAccountStatus).Valid) {
+            Write-Error "Not logged into LogicMonitor. Use Connect-LMAccount to log in and try again."
+            Return
+        }
 
-                # Get the existing rows for this alias (if any)
-                $aliasRows = $ExistingProps | Where-Object { $_.alias -eq $item.Alias }
-                if (-not $aliasRows) {
-                    # Alias doesn't exist at all, so create it with all standard properties
-                    Write-Host " -> Alias '$($item.Alias)' does not exist. Creating it with all standard properties..."
-                    New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
+        # 2. Define a static list of standard normalized properties
+        $NormalizedProperties = @(
+            [PSCustomObject]@{
+                Alias      = 'location.region'
+                Properties = @('location.region','auto.location.region')
+            },
+            [PSCustomObject]@{
+                Alias      = 'location.country'
+                Properties = @('location.country','auto.location.country')
+            },
+            [PSCustomObject]@{
+                Alias      = 'location.state'
+                Properties = @('location.state','auto.location.state')
+            },
+            [PSCustomObject]@{
+                Alias      = 'location.city'
+                Properties = @('location.city','auto.location.city')
+            },
+            [PSCustomObject]@{
+                Alias      = 'location.site'
+                Properties = @('location.site','auto.location.site')
+            },
+            [PSCustomObject]@{
+                Alias      = 'location.type'
+                Properties = @('location.type','auto.location.type')
+            },
+            [PSCustomObject]@{
+                Alias      = 'environment'
+                Properties = @('environment','system.aws.tag.environment','system.azure.tag.environment','system.gcp.tag.environment')
+            },
+            [PSCustomObject]@{
+                Alias      = 'owner'
+                Properties = @('owner','system.aws.tag.owner','system.azure.tag.owner','system.gcp.tag.owner')
+            },
+            [PSCustomObject]@{
+                Alias      = 'version'
+                Properties = @('version','system.aws.tag.version','system.azure.tag.version','system.gcp.tag.version')
+            },
+            [PSCustomObject]@{
+                Alias      = 'service'
+                Properties = @('service','system.aws.tag.service','system.azure.tag.service','system.gcp.tag.service')
+            },
+            [PSCustomObject]@{
+                Alias      = 'service_component'
+                Properties = @('service_component','system.aws.tag.service_component','system.azure.tag.service_component','system.gcp.tag.service_component')
+            },
+            [PSCustomObject]@{
+                Alias      = 'application'
+                Properties = @('application','system.aws.tag.application','system.azure.tag.application','system.gcp.tag.application')
+            }
+        )
+
+        # 3. Retrieve current normalized properties from LogicMonitor
+        $ExistingProps = Get-LMNormalizedProperties
+
+        # 4. Process each standard alias
+        foreach ($item in $NormalizedProperties) {
+            Write-Host "Checking alias: '$($item.Alias)'..."
+
+            # 4a. Get existing rows (if any) for this alias
+            $aliasRows = $ExistingProps | Where-Object { $_.alias -eq $item.Alias }
+
+            if (-not $aliasRows) {
+                # 4b. Alias does not exist -> Create it with all standard properties
+                Write-Host " -> Alias '$($item.Alias)' does not exist. Creating..."
+                New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
+            }
+            else {
+                Write-Host " -> Alias '$($item.Alias)' found. Checking for missing properties..."
+
+                # 4c. Determine which standard properties are missing
+                $aliasHostProps = $aliasRows.hostProperty
+                $missingProps   = $item.Properties | Where-Object { $aliasHostProps -notcontains $_ }
+
+                if ($missingProps) {
+                    Write-Host "    Missing properties: $($missingProps -join ', ')"
+                    # 4d. Add each missing property individually
+                    foreach ($prop in $missingProps) {
+                        Set-LMNormalizedProperties -Add -Alias $item.Alias -Properties @($prop)
+                    }
                 }
                 else {
-                    Write-Host " -> Alias '$($item.Alias)' found. Checking for any missing properties..."
-            
-                    # Gather which standard properties are missing
-                    $aliasHostProps = $aliasRows.hostProperty
-                    $missingProps   = $item.Properties | Where-Object { $aliasHostProps -notcontains $_ }
-
-                    if ($missingProps) {
-                        Write-Host "    Missing properties: $($missingProps -join ', ')"
-                        foreach($prop in $missingProps){
-                            Set-LMNormalizedProperties -Add -Alias $item.Alias -Properties @($prop)
-                        }
-                    }
-                    else {
-                        Write-Host "No missing properties. Nothing to do."
-                    }
+                    Write-Host "    No missing properties. Nothing to do."
                 }
             }
-        
-            Write-Host "`nAll standard normalized properties have been processed."
 
-        }Else {
-            Write-Error "Please ensure you are logged in before running any commands, use Connect-LMAccount to login and try again."
+            Write-Host  # Blank line for readability
         }
+
+        Write-Host "All standard normalized properties have been processed."
     }
     End {}
 }
-

--- a/Public/Initialize-LMStandardNormProps.ps1
+++ b/Public/Initialize-LMStandardNormProps.ps1
@@ -1,0 +1,84 @@
+<#
+.SYNOPSIS
+    Initializes standard normalized properties in LogicMonitor.
+
+.DESCRIPTION
+    This script defines a set of "standard" properties (like location.region, environment, etc.), 
+    then loops through each property to call "New-LMNormalizedProperties" with its alias 
+    and array of possible property names.
+
+.EXAMPLE
+    .\Initialize-LMStandardNormProps.ps1
+    Initializes all standard normalized properties.
+
+.NOTES
+    - Assumes you are already connected to LogicMonitor (e.g., via Connect-LMAccount).
+    - Requires a function named "New-LMNormalizedProperties" in scope.
+#>
+
+[CmdletBinding()]
+Param()
+
+# 1. Define the list of standard normalized properties as an array of PSCustomObjects.
+$NormalizedProperties = @(
+    [PSCustomObject]@{
+        Alias      = 'location.region'
+        Properties = @('sn.location.region','location.region','auto.location.region')
+    },
+    [PSCustomObject]@{
+        Alias      = 'location.country'
+        Properties = @('sn.location.country','location.country','auto.location.country')
+    },
+    [PSCustomObject]@{
+        Alias      = 'location.state'
+        Properties = @('sn.location.state','location.state','auto.location.state')
+    },
+    [PSCustomObject]@{
+        Alias      = 'location.city'
+        Properties = @('sn.location.city','location.city','auto.location.city')
+    },
+    [PSCustomObject]@{
+        Alias      = 'location.site'
+        Properties = @('sn.location.street','location.site','auto.location.site')
+    },
+    [PSCustomObject]@{
+        Alias      = 'location.type'
+        Properties = @('sn.location.type','location.type','auto.location.type')
+    },
+    [PSCustomObject]@{
+        Alias      = 'environment'
+        Properties = @('sn.environment','environment','system.aws.tag.environment','system.azure.tag.environment','system.gcp.tag.environment')
+    },
+    [PSCustomObject]@{
+        Alias      = 'owner'
+        Properties = @('sn.owner','owner','system.aws.tag.owner','system.azure.tag.owner','system.gcp.tag.owner')
+    },
+    [PSCustomObject]@{
+        Alias      = 'version'
+        Properties = @('version','system.aws.tag.version','system.azure.tag.version','system.gcp.tag.version')
+    },
+    [PSCustomObject]@{
+        Alias      = 'service'
+        Properties = @('sn.service.name','service','system.aws.tag.service','system.azure.tag.service','system.gcp.tag.service')
+    },
+    [PSCustomObject]@{
+        Alias      = 'service_component'
+        Properties = @('sn.service_component','service_component','system.aws.tag.service_component','system.azure.tag.service_component','system.gcp.tag.service_component')
+    },
+    [PSCustomObject]@{
+        Alias      = 'application'
+        Properties = @('sn.application','application','system.aws.tag.application','system.azure.tag.application','system.gcp.tag.application')
+    },
+    [PSCustomObject]@{
+        Alias      = 'customer'
+        Properties = @('sn.customer','customer','system.aws.tag.customer','system.azure.tag.customer','system.gcp.tag.customer')
+    }
+)
+
+# 2. Loop through each entry and call New-LMNormalizedProperties
+foreach ($item in $NormalizedProperties) {
+    Write-Host "Setting Normalized Property Alias: $($item.Alias)"
+    New-LMNormalizedProperties -Alias $item.Alias -Properties $item.Properties
+}
+
+Write-Host "All standard normalized properties have been initialized."


### PR DESCRIPTION
This PR adds the Initialize-LMStandardNormProps.ps1 script, which initializes standard normalized properties in LogicMonitor. 